### PR TITLE
Compatability fix with SS 3.0 Beta 2

### DIFF
--- a/code/GoogleSitemapDecorator.php
+++ b/code/GoogleSitemapDecorator.php
@@ -15,7 +15,7 @@ class GoogleSitemapDecorator extends DataExtension {
  */
 class GoogleSitemapSiteTreeDecorator extends DataExtension {
 
-	function extraStatics() {
+	function extraStatics($class = null, $extension = null) {
 		return array(
 			'db' => array(
 				"Priority" => "Varchar(5)",


### PR DESCRIPTION
BUGFIX: Fixed "Strict Standards" error with SilverStripe beta 2 caused by extraStatics() declaration not matching DataExtension
