### PR TITLE
A fix so that non-indexed pages remain non-indexed

### DIFF
--- a/code/GoogleSitemapDecorator.php
+++ b/code/GoogleSitemapDecorator.php
@@ -81,7 +81,7 @@ class GoogleSitemapSiteTreeDecorator extends SiteTreeDecorator {
 			return max(0.1, 1.0 - ($numParents / 10));
 		} 
 		elseif ($this->owner->getField('Priority') == -1) {
-			return 0;
+			return -1;
 		} 
 		else {
 			$priority = abs($this->owner->getField('Priority'));


### PR DESCRIPTION
Pages that were set to be "non-indexed" were being reset to their 
default priorities the next time that the page was saved. This fix
makes sure that this doesn't happen.
