### PR TITLE
API 3.1 compatibility: Static configurable properties must be private and immutable.

### DIFF
--- a/code/controllers/GoogleSitemapController.php
+++ b/code/controllers/GoogleSitemapController.php
@@ -17,7 +17,7 @@ class GoogleSitemapController extends Controller {
 	/**
 	 * @var array
 	 */
-	public static $allowed_actions = array(
+	private static $allowed_actions = array(
 		'index',
 		'sitemap'	
 	);

--- a/code/extensions/GoogleSitemapSiteTreeExtension.php
+++ b/code/extensions/GoogleSitemapSiteTreeExtension.php
@@ -8,7 +8,7 @@ class GoogleSitemapSiteTreeExtension extends GoogleSitemapExtension {
 	/**
 	 * @var array
 	 */
-	public static $db = array(
+	private static $db = array(
 		"Priority" => "Varchar(5)"
 	);
 


### PR DESCRIPTION
Static configurable properties (db, allowed_actions, etc) are now private. See: http://doc.silverstripe.org/framework/en/3.1/changelogs/3.1.0#static-properties-are-immutable-and-private-you-must-use-config-api
