### PR TITLE
Priority locale

### DIFF
--- a/code/extensions/GoogleSitemapSiteTreeExtension.php
+++ b/code/extensions/GoogleSitemapSiteTreeExtension.php
@@ -71,6 +71,7 @@ class GoogleSitemapSiteTreeExtension extends GoogleSitemapExtension {
 	 * @return mixed
 	 */
 	public function getGooglePriority() {
+		setlocale(LC_ALL, "en_US.UTF8");
 		$priority = $this->owner->getField('Priority');
 
 		if(!$priority) {


### PR DESCRIPTION
Bugfix: forced locale en_US for priority, since on some locale (eg. Italian) the separator is a comma.
