### PR TITLE
[FIX] canINcludeInGoogleSitemap

### DIFF
--- a/code/extensions/GoogleSitemapExtension.php
+++ b/code/extensions/GoogleSitemapExtension.php
@@ -14,23 +14,31 @@ class GoogleSitemapExtension extends DataExtension {
     public function canIncludeInGoogleSitemap() {
     	$can = true;
 
-    	if(method_exists($this, 'AbsoluteLink')) {
-			$objHttp = parse_url($this->AbsoluteLink(), PHP_URL_HOST);
-			$hostHttp = parse_url('http://' . $_SERVER['HTTP_HOST'], PHP_URL_HOST);
+		//if the class we're decorating has an AbsoluteLink method, we'll use
+		// it to determine if the page is on this domain - this hadnles
+		// RedirectorPages nicely
+    	if($this->owner->hasMethod('AbsoluteLink')) {
+			//parse out the hosts and compare them
+			$objHttp = parse_url($this->owner->AbsoluteLink(), PHP_URL_HOST);
+			$hostHttp = parse_url(Director::protocolAndHost(), PHP_URL_HOST);
 				
+			//if they don't match, then we won't add it
 			if($objHttp != $hostHttp) {
 				$can = false;
 			}
 		}
 		
 		if($can) {
+			//check we canView
 			$can = $this->owner->canView();
 		}
 
 		if($can) {
+			//only show priorities over 0%
 			$can = $this->owner->getGooglePriority();
 		}
 
+		//allow people to hook into the $can
 		$this->owner->extend('alterCanIncludeInGoogleSitemap', $can);
 
 		return $can;

--- a/tests/GoogleSitemapTest.php
+++ b/tests/GoogleSitemapTest.php
@@ -249,7 +249,7 @@ class GoogleSitemapTest_DataObject extends DataObject implements TestOnly {
 	}
 
 	public function AbsoluteLink() {
-		return Director::baseURL();
+		return Director::absoluteBaseURL();
 	}
 }
 
@@ -268,7 +268,7 @@ class GoogleSitemapTest_OtherDataObject extends DataObject implements TestOnly {
 	}
 
 	public function AbsoluteLink() {
-		return Director::baseURL();
+		return Director::absoluteBaseURL();
 	}
 }
 
@@ -287,6 +287,6 @@ class GoogleSitemapTest_UnviewableDataObject extends DataObject implements TestO
 	}
 
 	public function AbsoluteLink() {
-		return Director::baseURL();
+		return Director::absoluteBaseURL();
 	}
 }


### PR DESCRIPTION
It was not handling the URLs properly/parsing of the URLs, as well as missing ->owner.

Would really appreciate this being quickly patched as I need it to be working for a project.
