### PR TITLE
FIX Changing `alterCanIncludeInGoogleSitemap` to call owner and extensions

### DIFF
--- a/code/extensions/GoogleSitemapExtension.php
+++ b/code/extensions/GoogleSitemapExtension.php
@@ -31,7 +31,7 @@ class GoogleSitemapExtension extends DataExtension {
 			$can = $this->owner->getGooglePriority();
 		}
 
-		$this->owner->extend('alterCanIncludeInGoogleSitemap', $can);
+		$this->owner->invokeWithExtensions('alterCanIncludeInGoogleSitemap', $can);
 
 		return $can;
 	}


### PR DESCRIPTION
At the moment `alterCanIncludeInGoogleSitemap` is only called on other extensions, but really we'd want to see this called on the owner object and its extensions.

Fixed to use `invokeWithExtensions` rather than `extend`
