### PR TITLE
Make sure SiteTree sitemap index uses correct last edited value.

### DIFF
--- a/code/GoogleSitemap.php
+++ b/code/GoogleSitemap.php
@@ -271,10 +271,16 @@ class GoogleSitemap {
 
 			for($i = 1; $i <= $neededForPage; $i++) {
 				$sliced = $instances
-					->limit($countPerFile, ($i - 1) * $countPerFile)
-					->last();
+					->limit($countPerFile, ($i - 1) * $countPerFile);
+				$lastEdited = null;
 
-				$lastModified = ($sliced) ? $sliced->dbObject('LastEdited')->Format('Y-m-d') : date('Y-m-d');
+				foreach ($sliced as $page) {
+					if ($page->dbObject('LastEdited') > $lastEdited) {
+						$lastEdited = $page->dbObject('LastEdited');
+					}
+				}
+
+				$lastModified = ($lastEdited) ? $lastEdited->Format('Y-m-d') : date('Y-m-d');
 
 				$sitemaps->push(new ArrayData(array(
 					'ClassName' => 'SiteTree',


### PR DESCRIPTION
This is extremely inefficient but does handle the case where last in SiteTree (that is, the last one when sorted by Sort column) isn't the last updated.
