### PR TITLE
BUG Fix issue with children of unpublished pages appearing in sitemap as apparent root pages

### DIFF
--- a/code/extensions/GoogleSitemapSiteTreeExtension.php
+++ b/code/extensions/GoogleSitemapSiteTreeExtension.php
@@ -56,11 +56,33 @@ class GoogleSitemapSiteTreeExtension extends GoogleSitemapExtension {
 
 		$labels['Priority'] = _t('GoogleSitemaps.METAPAGEPRIO', "Page Priority");
 	}
+	
+	/**
+	 * Ensure that all parent pages of this page (if any) are published
+	 * 
+	 * @return boolean
+	 */
+	public function hasPublishedParent() {
+		
+		// Skip root pages
+		if(empty($this->owner->ParentID)) return true;
+		
+		// Ensure direct parent exists
+		$parent = $this->owner->Parent();
+		if(empty($parent) || !$parent->exists()) return false;
+		
+		// Check ancestry
+		return $parent->hasPublishedParent();
+	}
 
 	/**
 	 * @return boolean
 	 */
 	public function canIncludeInGoogleSitemap() {
+		
+		// Check that parent page is published
+		if(!$this->owner->hasPublishedParent()) return false;
+		
 		$result = parent::canIncludeInGoogleSitemap();
 		$result = ($this->owner instanceof ErrorPage) ? false : $result;
 


### PR DESCRIPTION
In sitetrees where an admin might temporarily unpublish a parent page of several child pages (such as a news or blog holder) those child pages are essentially orphaned on the live site. Unfortunately the sitemap.xml still attempts to list those child pages, but they are appearing as root pages due to the inaccessible parent. Of course, any of those links are 404s when accessed.

This fix ensures that any child of an unpublished page is hidden from the sitemap.

Tests included.
