### PR TITLE
Fix issue with last mod timestamp of the sitemap index file

### DIFF
--- a/code/GoogleSitemap.php
+++ b/code/GoogleSitemap.php
@@ -283,11 +283,12 @@ class GoogleSitemap {
 			$neededForPage = ceil($count / $countPerFile);
 
 			for($i = 1; $i <= $neededForPage; $i++) {
-				$sliced = $instances
-					->limit($countPerFile, ($i - 1) * $countPerFile)
-					->last();
 
-				$lastModified = ($sliced) ? $sliced->dbObject('LastEdited')->Format('Y-m-d') : date('Y-m-d');
+				$lastEdited = $instances
+					->limit($countPerFile, ($i - 1) * $countPerFile)
+					->max('LastEdited');
+
+				$lastModified = ($lastEdited) ? date('Y-m-d', strtotime($lastEdited)) : date('Y-m-d');
 
 				$sitemaps->push(new ArrayData(array(
 					'ClassName' => 'SiteTree',


### PR DESCRIPTION
Fix issue where the last mod timestamp of the sitemap index file wasnt using the most recently last edited timestamp, but the last item in the stack. This often meant editing a page wouldn't update the index file last mod date. Update test to check this, and include test for changeset bbd5e29
