### PR TITLE
add X-Robots-Tag header

### DIFF
--- a/code/controllers/GoogleSitemapController.php
+++ b/code/controllers/GoogleSitemapController.php
@@ -33,6 +33,7 @@ class GoogleSitemapController extends Controller {
 			Config::inst()->update('SSViewer', 'set_source_file_comments', false);
 			
 			$this->getResponse()->addHeader('Content-Type', 'application/xml; charset="utf-8"');
+			$this->getResponse()->addHeader('X-Robots-Tag', 'noindex');
 
 			$sitemaps = GoogleSitemap::get_sitemaps();
 			$this->extend('updateGoogleSitemaps', $sitemaps);
@@ -59,6 +60,7 @@ class GoogleSitemapController extends Controller {
 			Config::inst()->update('SSViewer', 'set_source_file_comments', false);
 			
 			$this->getResponse()->addHeader('Content-Type', 'application/xml; charset="utf-8"');
+			$this->getResponse()->addHeader('X-Robots-Tag', 'noindex');
 
 			$items = GoogleSitemap::get_items($class, $page);
 			$this->extend('updateGoogleSitemapItems', $items, $class, $page);


### PR DESCRIPTION
adding the X-Robots-Tag header might be a good thing, 
as it prevents the sitemap itself from getting indexed ~~by google~~ and showing up in the SERPs

see https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag
