### PR TITLE
Replacing deprecated $BaseHref in templates

### DIFF
--- a/templates/GoogleSitemapController.ss
+++ b/templates/GoogleSitemapController.ss
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type='text/xsl' href='{$BaseHref}googlesitemaps/templates/xml-sitemapindex.xsl'?>
+<?xml-stylesheet type='text/xsl' href='{$AbsoluteBaseURL}googlesitemaps/templates/xml-sitemapindex.xsl'?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><% loop Sitemaps %>
 	<sitemap>
-		<loc>{$BaseHref}sitemap.xml/sitemap/$ClassName/$Page.xml</loc>
+		<loc>{$AbsoluteBaseURL}sitemap.xml/sitemap/$ClassName/$Page.xml</loc>
 		<% if LastModified %><lastmod>$LastModified</lastmod><% end_if %>
 	</sitemap><% end_loop %>
 </sitemapindex>

--- a/templates/GoogleSitemapController_sitemap.ss
+++ b/templates/GoogleSitemapController_sitemap.ss
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type='text/xsl' href='{$BaseHref}googlesitemaps/templates/xml-sitemap.xsl'?>
+<?xml-stylesheet type='text/xsl' href='{$AbsoluteBaseURL}googlesitemaps/templates/xml-sitemap.xsl'?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 	<% loop $Items %>
         <url>


### PR DESCRIPTION
$BaseHref has been deprecated. I have replaced this in the templates with $AbsoluteBaseURL.
