### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"email": "will@fullscreen.io"
 	}],
 	"require": {
-		"silverstripe/framework": ">=3.1"
+		"silverstripe/framework": "^4"
 	},
 	"extra": {
         "installer-name": "googlesitemaps"


### PR DESCRIPTION
`master` branch of this module no longer works with SS3, due to the Director class being namespaced (so the URL rule no longer matches SS3 sites).