### PR TITLE
Add Subsite support

### DIFF
--- a/code/extensions/GoogleSitemapExtension.php
+++ b/code/extensions/GoogleSitemapExtension.php
@@ -18,6 +18,15 @@ class GoogleSitemapExtension extends DataExtension
 
         if ($this->owner->hasMethod('AbsoluteLink')) {
             $hostHttp = parse_url(Director::protocolAndHost(), PHP_URL_HOST);
+
+            // Subsite support
+            if (class_exists('Subsite')) {
+                // Subsite will have a different domain from Director::protocolAndHost
+                if ($subsite = Subsite::currentSubsite()) {
+                    $hostHttp = parse_url(Director::protocol() . $subsite->getPrimaryDomain(), PHP_URL_HOST);
+                }
+            }
+
             $objHttp = parse_url($this->owner->AbsoluteLink(), PHP_URL_HOST);
 
             if ($objHttp != $hostHttp) {


### PR DESCRIPTION
Ensures the host matches correctly to the current Subsite domain and protocol. Director::protocolAndHost() only retrieves the base, not the current Subsite.