### PR TITLE
EHANCEMENT/FIX: Make images optional (template and DataExtension)

### DIFF
--- a/src/Extensions/GoogleSitemapSiteTreeExtension.php
+++ b/src/Extensions/GoogleSitemapSiteTreeExtension.php
@@ -160,7 +160,7 @@ class GoogleSitemapSiteTreeExtension extends GoogleSitemapExtension
             }
         }
 
-        $this->owner->extend('updateImagesForSitemap', $list);
+        $list = $this->owner->extend('updateImagesForSitemap', $list);
 
         return $list;
     }

--- a/templates/xml-sitemap.ss
+++ b/templates/xml-sitemap.ss
@@ -42,29 +42,30 @@
                       <xsl:value-of select="sitemap:loc"/>
                     </a>
 
-
-                    <xsl:if test="\$imagesCount &gt; 0">
-                      <table class="imagestable" cellpadding="0" cellspacing="0">
-                        <tr>
-                          <th>Images</th>
-                        </tr>
-                        <xsl:for-each select="image:image">
-                          <xsl:variable name="imageURL">
-                            <xsl:value-of select="image:loc"/>
-                          </xsl:variable>
-                          <tr>
-                            <td>
-                              <img src="{\$imageURL}" width="40px"/>
-                            </td>
-                            <td>
-                              <a href="{\$imageURL}">
+                    <% if $imagesCount %>
+                        <xsl:if test="\$imagesCount &gt; 0">
+                          <table class="imagestable" cellpadding="0" cellspacing="0">
+                            <tr>
+                              <th>Images</th>
+                            </tr>
+                            <xsl:for-each select="image:image">
+                              <xsl:variable name="imageURL">
                                 <xsl:value-of select="image:loc"/>
-                              </a>
-                            </td>
-                          </tr>
-                        </xsl:for-each>
-                      </table>
-                    </xsl:if>
+                              </xsl:variable>
+                              <tr>
+                                <td>
+                                  <img src="{\$imageURL}" width="40px"/>
+                                </td>
+                                <td>
+                                  <a href="{\$imageURL}">
+                                    <xsl:value-of select="image:loc"/>
+                                  </a>
+                                </td>
+                              </tr>
+                            </xsl:for-each>
+                          </table>
+                        </xsl:if>
+                    <% end_if %>
 
 
                   </td>


### PR DESCRIPTION
I tried using the extension hook for images, to remove them from sitemap. Doesn't actually work because the return value is not saved to `$list` on return from the `DataExtension`. I have added the `$list` to save the return value of a `DataExtension`.

Removing images though, means that a check needed to be added to the template, to prevent it rendering empty images to the sitemap.xml view.