### PR TITLE
response was array, need to check boolean value

### DIFF
--- a/src/Extensions/GoogleSitemapExtension.php
+++ b/src/Extensions/GoogleSitemapExtension.php
@@ -66,6 +66,10 @@ class GoogleSitemapExtension extends DataExtension
             }
         }
 
+        if (is_array($can) && isset($can[0])) {
+            return $can[0];
+        }
+
         return $can;
     }
 

--- a/src/Extensions/GoogleSitemapSiteTreeExtension.php
+++ b/src/Extensions/GoogleSitemapSiteTreeExtension.php
@@ -103,6 +103,10 @@ class GoogleSitemapSiteTreeExtension extends GoogleSitemapExtension
         $result = parent::canIncludeInGoogleSitemap();
         $result = ($this->owner instanceof ErrorPage) ? false : $result;
 
+        if (is_array($result) && isset($result[0])) {
+            return $result[0];
+        }
+
         return $result;
     }
 


### PR DESCRIPTION
Fixes #166 

`canIncludeInGoogleSitemap()` returns an array, with one item which can be `false`, e.g. `$array[0] = false;`

GoogleSitemap.php checks as follows:
```
                if ($obj->canIncludeInGoogleSitemap()) {
                    $output->push($obj);
                }
```

Which will always return `true` if it is an array with count > 0, regardless of the value in first item.