### PR TITLE
Fixes has_one error 

### DIFF
--- a/src/Extensions/GoogleSitemapSiteTreeExtension.php
+++ b/src/Extensions/GoogleSitemapSiteTreeExtension.php
@@ -135,6 +135,10 @@ class GoogleSitemapSiteTreeExtension extends GoogleSitemapExtension
         $cachedImages = [];
 
         foreach ($this->owner->hasOne() as $field => $type) {
+            if (strpos($type, '.') !== false) {
+                $type = explode('.', $type)[0];
+            }
+
             if (singleton($type) instanceof Image) {
                 $image = $this->owner->getComponent($field);
 


### PR DESCRIPTION
[Emergency] Uncaught SilverStripe\Core\Injector\InjectorNotFoundException: ReflectionException: Class App\Web\Label.Status does not exist in /var/www/html/vendor/silverstripe/framework/src/Core/Injector/InjectionCreator.php:17

 when there is a has_one relation similar to this 

```
private static $has_one = array(
        'SelectedStatus' => Label::class.'.Status',
    );
```