### PR TITLE
fix: added type check for other id

### DIFF
--- a/src/Control/GoogleSitemapController.php
+++ b/src/Control/GoogleSitemapController.php
@@ -70,6 +70,12 @@ class GoogleSitemapController extends Controller
         $class = $this->unsanitiseClassName($this->request->param('ID'));
         $page = $this->request->param('OtherID');
 
+        if ($page) {
+            if (!is_numeric($page)) {
+                return new HTTPResponse('Page not found', 404);
+            }
+        }
+
         if (GoogleSitemap::enabled()
             && $class
             && $page


### PR DESCRIPTION
Closes #183 

### Summary
Type check for the OtherID url param. Returns a 404 for routes like: "/sitemap.xml/sitemap/SilverStripe-CMS-Model-SiteTree/@@Axggw".

Based on 2.x for PHP 7.3 compatibility.