### PR TITLE
Fix absolute link scope

### DIFF
--- a/templates/Wilr/GoogleSitemaps/Control/GoogleSitemapController.ss
+++ b/templates/Wilr/GoogleSitemaps/Control/GoogleSitemapController.ss
@@ -2,7 +2,7 @@
 <?xml-stylesheet type='text/xsl' href='{$AbsoluteLink('styleSheetIndex')}'?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><% loop Sitemaps %>
     <sitemap>
-        <loc>{$AbsoluteLink('sitemap')}/{$ClassName}/{$Page.xml}</loc>
+        <loc>{$Up.AbsoluteLink('sitemap')}/{$ClassName}/{$Page.xml}</loc>
         <% if $LastModified %><lastmod>{$LastModified}</lastmod><% end_if %>
     </sitemap><% end_loop %>
 </sitemapindex>


### PR DESCRIPTION
One of the `$AbsoluteLink` usages in `GoogleSitemapController.ss` is inside the loop but missing the `$Up.` prefix, breaking the sitemap index. Tested and working with this fix. 