### PR TITLE
Ensure trailing slash removed from AbsoluteLink

### DIFF
--- a/src/Control/GoogleSitemapController.php
+++ b/src/Control/GoogleSitemapController.php
@@ -133,6 +133,6 @@ class GoogleSitemapController extends Controller
 
     public function AbsoluteLink($action = null)
     {
-        return Controller::join_links(Director::absoluteBaseURL(), 'sitemap.xml', $action);
+        return rtrim(Controller::join_links(Director::absoluteBaseURL(), 'sitemap.xml', $action), '/');
     }
 }


### PR DESCRIPTION
This is to resolve duplicated trailing slash when add_trailing_slash property is set to true in YML config.

Also, relates to #188