### PR TITLE
BUG - Pass empty string instead of null when no image exists

### DIFF
--- a/src/Extensions/GoogleSitemapExtension.php
+++ b/src/Extensions/GoogleSitemapExtension.php
@@ -33,7 +33,7 @@ class GoogleSitemapExtension extends DataExtension
                 }
             }
 
-            $objHttp = parse_url($this->owner->AbsoluteLink(), PHP_URL_HOST);
+            $objHttp = parse_url($this->owner->AbsoluteLink() ?? '', PHP_URL_HOST);
 
             if ($objHttp != $hostHttp) {
                 $can = false;


### PR DESCRIPTION
Hi, 

An error is encountered when a null value is passed to the parse_url function. The specific error message is as follows:
```[Deprecated] parse_url(): Passing null to parameter #1 ($url) of type string is deprecated```


Steps to Generate - 

 I added File object to the `GoogleSitemap::register_daaobject`. Some of these files do not currently exist in the assets but have a database entry. When accessing the File Sitemap, the above error is thrown. This issue is observed with the latest tag on SilverStripe 5.